### PR TITLE
增加功耗采样时间

### DIFF
--- a/showtempcpufreq.sh
+++ b/showtempcpufreq.sh
@@ -118,7 +118,7 @@ $res->{cpuFreq} = `
 	echo -n 'max:'
 	cat /sys/devices/system/cpu/cpufreq/policy0/cpuinfo_max_freq
 	echo -n 'pkgwatt:'
-	[ -e /usr/sbin/turbostat ] && turbostat --quiet --cpu package --show "PkgWatt" -S sleep 0 2>&1| tail -n1
+	[ -e /usr/sbin/turbostat ] && turbostat --quiet --cpu package --show "PkgWatt" -S sleep 0.25 2>&1| tail -n1
 
 `;
 EOF


### PR DESCRIPTION
![image](https://github.com/a904055262/PVE-manager-status/assets/92856393/47e332d2-8745-4074-9e21-d612b27c4f7d)
1ms的采样时长也许对于低功耗平台还好，但是功耗较高的平台得到的功耗波动和误差太大了（哪儿有U能跑1000w的），很难抓到当前的真实功耗，应该适当增加采样时间，100ms也有较大的波动，250ms差不多合适